### PR TITLE
Remove call to deprecated addClassesToCompile

### DIFF
--- a/src/DependencyInjection/ProophEventStoreExtension.php
+++ b/src/DependencyInjection/ProophEventStoreExtension.php
@@ -45,10 +45,6 @@ final class ProophEventStoreExtension extends Extension
         if (! empty($config['stores'])) {
             $this->loadEventStores(EventStore::class, $config, $container);
         }
-
-        $this->addClassesToCompile([
-            EventStore::class,
-        ]);
     }
 
     /**


### PR DESCRIPTION
addClassesToCompile is deprecated in Symfony 3.3 (for PHP 7) and will be removed in Symfony 4.0. https://github.com/symfony/symfony/blob/master/UPGRADE-3.3.md#httpkernel

As Prooph already requires PHP 7 adding classes to compile has no affect.