### PR TITLE
Remove the projection name argument from projection names command

### DIFF
--- a/src/Command/AbstractProjectionCommand.php
+++ b/src/Command/AbstractProjectionCommand.php
@@ -12,13 +12,14 @@ use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\EventStore\Projection\Projector;
 use Prooph\EventStore\Projection\ReadModelProjector;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractProjectionCommand extends ContainerAwareCommand
 {
+    use FormatsOutput;
+
     protected const ARGUMENT_PROJECTION_NAME = 'projection-name';
 
     /**
@@ -55,10 +56,7 @@ abstract class AbstractProjectionCommand extends ContainerAwareCommand
     {
         $input->validate();
 
-        $outputFormatter = $output->getFormatter();
-        $outputFormatter->setStyle('header', new OutputFormatterStyle('green', null));
-        $outputFormatter->setStyle('highlight', new OutputFormatterStyle('green', null, ['bold']));
-        $outputFormatter->setStyle('action', new OutputFormatterStyle('blue', null));
+        $this->formatOutput($output);
 
         $this->projectionName = $input->getArgument(static::ARGUMENT_PROJECTION_NAME);
 

--- a/src/Command/FormatsOutput.php
+++ b/src/Command/FormatsOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\Bundle\EventStore\Command;
+
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait FormatsOutput
+{
+    protected function formatOutput(OutputInterface $output)
+    {
+        $outputFormatter = $output->getFormatter();
+        $outputFormatter->setStyle('header', new OutputFormatterStyle('green', null));
+        $outputFormatter->setStyle('highlight', new OutputFormatterStyle('green', null, ['bold']));
+        $outputFormatter->setStyle('action', new OutputFormatterStyle('blue', null));
+    }
+}

--- a/src/Command/ProjectionNamesCommand.php
+++ b/src/Command/ProjectionNamesCommand.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\EventStore\Command;
 
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ProjectionNamesCommand extends AbstractProjectionCommand
+class ProjectionNamesCommand extends ContainerAwareCommand
 {
+    use FormatsOutput;
+
     private const ARGUMENT_FILTER = 'filter';
     private const OPTION_REGEX = 'regex';
     private const OPTION_LIMIT = 'limit';
     private const OPTION_OFFSET = 'offset';
+    private const OPTION_MANAGER = 'manager';
 
     protected function configure()
     {
@@ -24,11 +29,22 @@ class ProjectionNamesCommand extends AbstractProjectionCommand
             ->addArgument(self::ARGUMENT_FILTER, InputArgument::OPTIONAL, 'Filter by this string')
             ->addOption(self::OPTION_REGEX, 'r', InputOption::VALUE_NONE, 'Enable regex syntax for filter')
             ->addOption(self::OPTION_LIMIT, 'l', InputOption::VALUE_REQUIRED, 'Limit the result set', 20)
-            ->addOption(self::OPTION_OFFSET, 'o', InputOption::VALUE_REQUIRED, 'Offset for result set', 0);
+            ->addOption(self::OPTION_OFFSET, 'o', InputOption::VALUE_REQUIRED, 'Offset for result set', 0)
+            ->addOption(self::OPTION_MANAGER, 'm', InputOption::VALUE_REQUIRED, 'Manager for result set', null);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->formatOutput($output);
+
+        $managerNames = array_keys($this->getContainer()->getParameter('prooph_event_store.projection_managers'));
+
+        if ($requestedManager = $input->getOption(self::OPTION_MANAGER)) {
+            $managerNames = array_filter($managerNames, function (string $managerName) use ($requestedManager) {
+                return $managerName === $requestedManager;
+            });
+        }
+
         $filter = $input->getArgument(self::ARGUMENT_FILTER);
         $regex = $input->getOption(static::OPTION_REGEX);
 
@@ -44,12 +60,36 @@ class ProjectionNamesCommand extends AbstractProjectionCommand
         }
         $output->writeln('</action>');
 
-        $output->writeln(
-            json_encode($this->projectionManager->$method(
-                $filter,
-                $input->getOption(self::OPTION_LIMIT),
-                $input->getOption(self::OPTION_OFFSET)
-            ), JSON_PRETTY_PRINT)
-        );
+        $names = [];
+        $offset = (int) $input->getOption(self::OPTION_OFFSET);
+        $limit = (int) $input->getOption(self::OPTION_LIMIT);
+        $maxNeeded = $offset + $limit;
+
+        foreach ($managerNames as $managerName) {
+            $projectionManager = $this->getContainer()->get('prooph_event_store.projection_manager.' . $managerName);
+
+            if (count($names) > $offset) {
+                $projectionNames = $projectionManager->$method($filter, $limit - (count($names) - $offset));
+            } else {
+                $projectionNames = $projectionManager->$method($filter);
+            }
+
+            foreach ($projectionNames as $projectionName) {
+                $names[] = [$managerName, $projectionName];
+            }
+
+            if (count($names) >= $maxNeeded) {
+                break;
+            }
+        }
+
+        $names = array_slice($names, $offset, $limit);
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Projection Manager', 'Name'])
+            ->setRows($names);
+
+        $table->render();
     }
 }

--- a/src/DependencyInjection/ProophEventStoreExtension.php
+++ b/src/DependencyInjection/ProophEventStoreExtension.php
@@ -60,6 +60,8 @@ final class ProophEventStoreExtension extends Extension
 
     public function loadProjectionManagers(array $config, ContainerBuilder $container)
     {
+        $projectionManagers = [];
+
         foreach ($config['projection_managers'] as $projectionManagerName => $projectionManagerConfig) {
             $projectionManagerDefintion = new Definition();
             $projectionManagerDefintion
@@ -78,7 +80,11 @@ final class ProophEventStoreExtension extends Extension
             );
 
             $this->loadProjections($projectionManagerConfig, $projectionManagerName, $container);
+
+            $projectionManagers[$projectionManagerName] = 'prooph_event_store.'.$projectionManagerName;
         }
+
+        $container->setParameter('prooph_event_store.projection_managers', $projectionManagers);
     }
 
     public function loadProjections(array $config, string $projectionManager, ContainerBuilder $container)


### PR DESCRIPTION
I don't know of a way to remove the required argument and maintain the inheritance from the abstract class, especially since that argument is used in the initialization, so I decided to remove the inheritance instead.

Fixes https://github.com/prooph/event-store-symfony-bundle/issues/21