### PR TITLE
Allow developing under PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,8 @@
     "symfony/yaml" : "~2.8 || ~3.0",
     "bookdown/bookdown": "1.x-dev as 1.0.0",
     "prooph/bookdown-template": "^0.2.3",
-    "friendsofphp/php-cs-fixer": " ~2.0",
-    "prooph/php-cs-fixer-config": "^0.1.1"
+    "friendsofphp/php-cs-fixer": " ^2.8.1",
+    "prooph/php-cs-fixer-config": "^0.2.1"
   },
   "suggest": {
     "prooph/event-store-bus-bridge": "To Marry CQRS (ProophSerivceBus) with Event Sourcing"


### PR DESCRIPTION
`php-cs-fixer:2.0.0` (required by `php-cs-fixer-config:^0.1.1`) blocks installing on PHP 7.2