### PR TITLE
fix the symfony 4 deprecation error for the projection manager

### DIFF
--- a/src/DependencyInjection/ProophEventStoreExtension.php
+++ b/src/DependencyInjection/ProophEventStoreExtension.php
@@ -13,6 +13,7 @@ namespace Prooph\Bundle\EventStore\DependencyInjection;
 
 use Prooph\Bundle\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Projection\ProjectionManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -67,6 +68,7 @@ final class ProophEventStoreExtension extends Extension
             $projectionManagerDefintion = new Definition();
             $projectionManagerDefintion
                 ->setFactory([new Reference('prooph_event_store.projection_factory'), 'createProjectionManager'])
+                ->setClass(ProjectionManager::class)
                 ->setArguments([
                     new Reference($projectionManagerConfig['event_store']),
                     new Reference($projectionManagerConfig['connection']),


### PR DESCRIPTION
Fix the error:

> Relying on its factory's return-type to define the class of service "prooph_event_store.projection_manager.bef_projection_manager" is deprecated since Symfony 3.3 and won't work in 4.0. Set the "class" attribute to "Prooph\EventStore\Projection\ProjectionManager" on the service definition instead.