### PR TITLE
Deprecated relying on its factory's return-type to define the class of service

### DIFF
--- a/src/DependencyInjection/ProophEventStoreExtension.php
+++ b/src/DependencyInjection/ProophEventStoreExtension.php
@@ -13,6 +13,7 @@ namespace Prooph\Bundle\EventStore\DependencyInjection;
 
 use Prooph\Bundle\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Projection\ProjectionManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -69,10 +70,11 @@ final class ProophEventStoreExtension extends Extension
                 ->setFactory([new Reference('prooph_event_store.projection_factory'), 'createProjectionManager'])
                 ->setArguments([
                     new Reference($projectionManagerConfig['event_store']),
-                    new Reference($projectionManagerConfig['connection']),
+                    isset($projectionManagerConfig['connection']) ? new Reference($projectionManagerConfig['connection']) : null,
                     $projectionManagerConfig['event_streams_table'],
                     $projectionManagerConfig['projections_table'],
-                ]);
+                ])
+                ->setClass(ProjectionManager::class);
 
             $projectorManagerId = sprintf('prooph_event_store.projection_manager.%s', $projectionManagerName);
             $container->setDefinition(

--- a/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\Bundle\EventStore\DependencyInjection\ProophEventStoreExtension;
 use Prooph\Bundle\EventStore\ProophEventStoreBundle;
 use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\SnapshotStore\SnapshotStore;
 use ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository;
 use Symfony\Component\Config\FileLocator;
@@ -59,6 +60,9 @@ abstract class AbstractEventStoreExtensionTestCase extends TestCase
 
         $snapshotStore = $container->get('prooph_test.bundle.snapshot_store.in_memory');
         self::assertInstanceOf(SnapshotStore::class, $snapshotStore);
+
+        $projectionManager = $container->get('prooph_event_store.projection_manager.main_projection_manager');
+        self::assertInstanceOf(ProjectionManager::class, $projectionManager);
     }
 
     /**

--- a/test/DependencyInjection/Fixture/Projection/TodoProjection.php
+++ b/test/DependencyInjection/Fixture/Projection/TodoProjection.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 namespace ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection;
 
 use Prooph\Bundle\EventStore\Projection\ReadModelProjection;
@@ -7,7 +8,6 @@ use Prooph\EventStore\Projection\ReadModelProjector;
 
 final class TodoProjection implements ReadModelProjection
 {
-
     public function project(ReadModelProjector $projector): ReadModelProjector
     {
     }

--- a/test/DependencyInjection/Fixture/Projection/TodoProjection.php
+++ b/test/DependencyInjection/Fixture/Projection/TodoProjection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection;
+
+use Prooph\Bundle\EventStore\Projection\ReadModelProjection;
+use Prooph\EventStore\Projection\ReadModelProjector;
+
+final class TodoProjection implements ReadModelProjection
+{
+
+    public function project(ReadModelProjector $projector): ReadModelProjector
+    {
+    }
+}

--- a/test/DependencyInjection/Fixture/Projection/TodoReadModel.php
+++ b/test/DependencyInjection/Fixture/Projection/TodoReadModel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection;
+
+use Prooph\EventStore\Projection\AbstractReadModel;
+
+final class TodoReadModel extends AbstractReadModel
+{
+
+    public function init(): void
+    {
+    }
+
+    public function isInitialized(): bool
+    {
+        return false;
+    }
+
+    public function reset(): void
+    {
+    }
+
+    public function delete(): void
+    {
+    }
+}

--- a/test/DependencyInjection/Fixture/Projection/TodoReadModel.php
+++ b/test/DependencyInjection/Fixture/Projection/TodoReadModel.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
 namespace ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection;
 
 use Prooph\EventStore\Projection\AbstractReadModel;
 
 final class TodoReadModel extends AbstractReadModel
 {
-
     public function init(): void
     {
     }

--- a/test/DependencyInjection/Fixture/config/xml/event_store.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_store.xml
@@ -21,5 +21,19 @@
                 <aggregate_translator>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregateTranslator</aggregate_translator>
             </repository>
         </store>
+        <projection_managers>
+            <projection_manager name="main_projection_manager">
+                <event_store>Prooph\EventStore\InMemoryEventStore</event_store>
+                    <projections>
+                        <projection name="todo_projection">
+                            <read_model>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel</read_model>
+                            <projection>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoProjection</projection>
+                        </projection>
+                    </projections>
+            </projection_manager>
+        </projection_managers>
     </config>
+    <srv:services>
+        <srv:service id="Prooph\EventStore\InMemoryEventStore" class="Prooph\EventStore\InMemoryEventStore" />
+    </srv:services>
 </srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/event_store.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_store.yml
@@ -13,3 +13,14 @@ prooph_event_store:
          ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository:
             aggregate_type: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregate'
             aggregate_translator: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregateTranslator'
+  projection_managers:
+      main_projection_manager:
+        event_store: 'Prooph\EventStore\InMemoryEventStore'
+        projections:
+          todo_projection:
+            read_model: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel'
+            projection: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoProjection'
+
+services:
+  Prooph\EventStore\InMemoryEventStore:
+    class: Prooph\EventStore\InMemoryEventStore


### PR DESCRIPTION
Changes introduced:
- added class info to projection manager DI definition
- added tests to check if projection manager is created
- skipping the connection setting if it is not provided by the configuration (it is not required)