### PR TITLE
Incorrect repository configuration leading to TypeError

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -121,8 +121,8 @@ final class Configuration implements ConfigurationInterface
         $repositoryNode
             ->children()
                 ->scalarNode('repository_class')->end()
-                ->scalarNode('aggregate_type')->end()
-                ->scalarNode('aggregate_translator')
+                ->scalarNode('aggregate_type')->isRequired()->end()
+                ->scalarNode('aggregate_translator')->isRequired()
                     ->beforeNormalization()
                         ->ifTrue($beginsWithAt)
                         ->then($removeFirstCharacter)

--- a/src/DependencyInjection/ProophEventStoreExtension.php
+++ b/src/DependencyInjection/ProophEventStoreExtension.php
@@ -206,7 +206,7 @@ final class ProophEventStoreExtension extends Extension
 
                 if (! class_exists($repositoryClass)) {
                     throw new RuntimeException(sprintf(
-                        "Configure repository class using either passing FQCN as a key or 'repository_class' configuration key. Given: %s",
+                        'You must configure the class of repository "%s" either by configuring the \'repository_class\' key or by directly using the FQCN as the repository key.',
                         $repositoryClass
                     ));
                 }

--- a/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
@@ -187,6 +187,26 @@ abstract class AbstractEventStoreExtensionTestCase extends TestCase
         $this->loadContainer('missing_projection_key');
     }
 
+    /**
+     * @test
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The child node "aggregate_type" at path "prooph_event_store.stores.main_store.repositories.todo_list" must be configured.
+     */
+    public function it_expects_repository_nodes_to_have_an_aggregate_type_key()
+    {
+        $this->loadContainer('missing_aggregate_type_key');
+    }
+
+    /**
+     * @test
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The child node "aggregate_translator" at path "prooph_event_store.stores.main_store.repositories.todo_list" must be configured.
+     */
+    public function it_expects_repository_nodes_to_have_an_aggregate_translator_key()
+    {
+        $this->loadContainer('missing_aggregate_translator_key');
+    }
+
     private function loadContainer($fixture, CompilerPassInterface $compilerPass = null)
     {
         $container = $this->getContainer();

--- a/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
@@ -190,6 +190,7 @@ abstract class AbstractEventStoreExtensionTestCase extends TestCase
     /**
      * @test
      * @expectedException Prooph\Bundle\EventStore\Exception\RuntimeException
+     * @expectedExceptionMessage You must configure the class of repository "todo_list" either by configuring the 'repository_class' key or by directly using the FQCN as the repository key.
      */
     public function it_expects_repository_nodes_to_have_a_repository_class()
     {

--- a/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
@@ -189,6 +189,15 @@ abstract class AbstractEventStoreExtensionTestCase extends TestCase
 
     /**
      * @test
+     * @expectedException Prooph\Bundle\EventStore\Exception\RuntimeException
+     */
+    public function it_expects_repository_nodes_to_have_a_repository_class()
+    {
+        $this->loadContainer('missing_repository_class');
+    }
+
+    /**
+     * @test
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage The child node "aggregate_type" at path "prooph_event_store.stores.main_store.repositories.todo_list" must be configured.
      */

--- a/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractEventStoreExtensionTestCase.php
@@ -177,6 +177,16 @@ abstract class AbstractEventStoreExtensionTestCase extends TestCase
         $this->dump('metadata_enricher');
     }
 
+    /**
+     * @test
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The child node "projection" at path "prooph_event_store.projection_managers.main_projection_manager.projections.todo_projection" must be configured.
+     */
+    public function it_expects_projection_nodes_to_have_a_projection_key(): void
+    {
+        $this->loadContainer('missing_projection_key');
+    }
+
     private function loadContainer($fixture, CompilerPassInterface $compilerPass = null)
     {
         $container = $this->getContainer();

--- a/test/DependencyInjection/Fixture/config/xml/missing_aggregate_translator_key.xml
+++ b/test/DependencyInjection/Fixture/config/xml/missing_aggregate_translator_key.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/event_store-5.1.xsd">
+    <config>
+        <store name="main_store" event_store="ProophTest\Bundle\EventStore\DependencyInjection\Fixture\EventStore\BlackHole">
+            <repository name="todo_list">
+                <repository_class>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository</repository_class>
+                <aggregate_type>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregate</aggregate_type>
+                <snapshot_store>prooph_test.bundle.snapshot_store.in_memory</snapshot_store>
+                <stream_name>test</stream_name>
+                <one_stream_per_aggregate>true</one_stream_per_aggregate>
+            </repository>
+        </store>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/missing_aggregate_type_key.xml
+++ b/test/DependencyInjection/Fixture/config/xml/missing_aggregate_type_key.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/event_store-5.1.xsd">
+    <config>
+        <store name="main_store" event_store="ProophTest\Bundle\EventStore\DependencyInjection\Fixture\EventStore\BlackHole">
+            <repository name="todo_list">
+                <repository_class>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository</repository_class>
+                <aggregate_translator>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregateTranslator</aggregate_translator>
+                <snapshot_store>prooph_test.bundle.snapshot_store.in_memory</snapshot_store>
+                <stream_name>test</stream_name>
+                <one_stream_per_aggregate>true</one_stream_per_aggregate>
+            </repository>
+        </store>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/missing_projection_key.xml
+++ b/test/DependencyInjection/Fixture/config/xml/missing_projection_key.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/event_store-5.1.xsd">
+    <config>
+        <projection_managers>
+            <projection_manager name="main_projection_manager">
+                <event_store>Prooph\EventStore\InMemoryEventStore</event_store>
+                    <projections>
+                        <projection name="todo_projection">
+                            <read_model>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel</read_model>
+                        </projection>
+                    </projections>
+            </projection_manager>
+        </projection_managers>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/missing_repository_class.xml
+++ b/test/DependencyInjection/Fixture/config/xml/missing_repository_class.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/event_store-5.1.xsd">
+    <config>
+        <store name="main_store" event_store="ProophTest\Bundle\EventStore\DependencyInjection\Fixture\EventStore\BlackHole">
+            <repository name="todo_list">
+                <aggregate_type>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregate</aggregate_type>
+                <aggregate_translator>ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregateTranslator</aggregate_translator>
+                <snapshot_store>prooph_test.bundle.snapshot_store.in_memory</snapshot_store>
+                <stream_name>test</stream_name>
+                <one_stream_per_aggregate>true</one_stream_per_aggregate>
+            </repository>
+        </store>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/missing_aggregate_translator_key.yml
+++ b/test/DependencyInjection/Fixture/config/yml/missing_aggregate_translator_key.yml
@@ -1,0 +1,8 @@
+prooph_event_store:
+  stores:
+    main_store:
+      event_store: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\EventStore\BlackHole'
+      repositories:
+         todo_list:
+            repository_class: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository'
+            aggregate_type: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregate'

--- a/test/DependencyInjection/Fixture/config/yml/missing_aggregate_type_key.yml
+++ b/test/DependencyInjection/Fixture/config/yml/missing_aggregate_type_key.yml
@@ -1,0 +1,8 @@
+prooph_event_store:
+  stores:
+    main_store:
+      event_store: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\EventStore\BlackHole'
+      repositories:
+         todo_list:
+            repository_class: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository'
+            aggregate_translator: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregateTranslator'

--- a/test/DependencyInjection/Fixture/config/yml/missing_projection_key.yml
+++ b/test/DependencyInjection/Fixture/config/yml/missing_projection_key.yml
@@ -1,0 +1,7 @@
+prooph_event_store:
+  projection_managers:
+    main_projection_manager:
+      event_store: 'Prooph\EventStore\InMemoryEventStore'
+      projections:
+        todo_projection:
+          read_model: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel'

--- a/test/DependencyInjection/Fixture/config/yml/missing_repository_class.yml
+++ b/test/DependencyInjection/Fixture/config/yml/missing_repository_class.yml
@@ -1,0 +1,8 @@
+prooph_event_store:
+  stores:
+    main_store:
+      event_store: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\EventStore\BlackHole'
+      repositories:
+         todo_list:
+            aggregate_type: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregate'
+            aggregate_translator: 'ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggregateTranslator'


### PR DESCRIPTION
In the case when an `aggregate_type` or an `aggregate_translator` value has been forgotten when configuring a repository, an ugly `TypeError` will be thrown.

This PR intends to fix that by requiring these values.

I've also improved (I think) the error message when the `repository_class` is not provided, let me know if you prefer the previous message.