### PR TITLE
Fix projection locators

### DIFF
--- a/src/DependencyInjection/Compiler/ProjectorPass.php
+++ b/src/DependencyInjection/Compiler/ProjectorPass.php
@@ -29,6 +29,7 @@ final class ProjectorPass implements CompilerPassInterface
         $projectors = $container->findTaggedServiceIds(ProophEventStoreExtension::TAG_PROJECTION);
         $readModelsLocator = [];
         $projectionManagerForProjectionsLocator = [];
+        $projectionsLocator = [];
 
         foreach ($projectors as $id => $projector) {
             $projectorDefinition = $container->getDefinition($id);


### PR DESCRIPTION
Currently projections don't work as [documented](https://github.com/prooph/event-store-symfony-bundle/pull/27/files#diff-90c9589ad47ad0f855298dd39a5ae294). When I run `bin/console event-store:projection:run main` I get `ProjectionManager for "main" not found` even though I correctly registered the projection using a tag.

The problem is that the `projection_manager_for_projections_locator` and `projections_locator` used by `AbstractProjectionCommand` only have references for projections from central configuration. Projections registered by tag are missing.

I've fixed that in this PR but I don't really like the implementation. I'm not a fan of 2 ways to define the same thing but changing it to tags only would be a BC break. Any tips how to make the implementation better?