### PR TITLE
Corrects TreeBuilder deprecation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -91,7 +91,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->scalarNode('event_streams_table')->defaultValue('event_streams')->end()
-                    ->scalarNode('projections_table')->defaultValue(self::PROJECTIONS_NODE)->end()
+                    ->scalarNode('projections_table')->defaultValue('projections')->end()
                     ->append($projectionsNode)
                 ->end()
             ->end();
@@ -150,7 +150,7 @@ final class Configuration implements ConfigurationInterface
                 ->requiresAtLeastOneElement()
                 ->useAttributeAsKey('name')
                 ->prototype('array')
-                ->fixXmlConfig('repository', self::REPOSITORIES_NODE)
+                ->fixXmlConfig('repository', 'repositories')
                 ->children()
                     ->scalarNode('event_emitter')
                         ->defaultValue(ProophActionEventEmitter::class)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('prooph_event_store');
         /** @var ArrayNodeDefinition $rootNode */
-        $rootNode = $treeBuilder->root('prooph_event_store');
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addEventStoreSection($rootNode);
         $this->addProjectionManagerSection($rootNode);
@@ -38,9 +38,9 @@ final class Configuration implements ConfigurationInterface
 
     public function addProjectionManagerSection(ArrayNodeDefinition $node): void
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('projections');
         /** @var ArrayNodeDefinition $projectionsNode */
-        $projectionsNode = $treeBuilder->root('projections');
+        $projectionsNode = $treeBuilder->getRootNode();
 
         $beginsWithAt = function ($v) {
             return \strpos($v, '@') === 0;
@@ -104,9 +104,9 @@ final class Configuration implements ConfigurationInterface
      */
     private function addEventStoreSection(ArrayNodeDefinition $node): void
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('repositories');
         /** @var ArrayNodeDefinition $repositoriesNode */
-        $repositoriesNode = $treeBuilder->root('repositories');
+        $repositoriesNode = $treeBuilder->getRootNode();
 
         $beginsWithAt = function ($v) {
             return \strpos($v, '@') === 0;


### PR DESCRIPTION
Hi,

It's not an image but it definitely worth a thousand words :)

> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

P.S.: For this one I didn't see the point of an issue first :smile: