### PR TITLE
Make ProjectionManagerFactory handle decorated EventStores

### DIFF
--- a/test/ProjectionManagerFactoryTest.php
+++ b/test/ProjectionManagerFactoryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\EventStore;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Prooph\Bundle\EventStore\Exception\RuntimeException;
+use Prooph\Bundle\EventStore\ProjectionManagerFactory;
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\EventStoreDecorator;
+use Prooph\EventStore\InMemoryEventStore;
+use Prooph\EventStore\Pdo\MariaDbEventStore;
+use Prooph\EventStore\Pdo\MySqlEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\Pdo\PostgresEventStore;
+use Prooph\EventStore\Pdo\Projection\MariaDbProjectionManager;
+use Prooph\EventStore\Pdo\Projection\MySqlProjectionManager;
+use Prooph\EventStore\Pdo\Projection\PostgresProjectionManager;
+use Prooph\EventStore\Projection\InMemoryProjectionManager;
+
+class ProjectionManagerFactoryTest extends TestCase
+{
+    /**
+     * @var ProjectionManagerFactory
+     */
+    private $sut;
+
+    protected function setUp()
+    {
+        $this->sut = new ProjectionManagerFactory();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_accept_an_unknown_event_store()
+    {
+        $unknownEventStore = $this->getMockForAbstractClass(EventStore::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'ProjectionManager for %s not implemented.',
+            \get_class($unknownEventStore)
+        ));
+
+        $this->sut->createProjectionManager($unknownEventStore);
+    }
+
+    /**
+     * @test
+     * @dataProvider provideEventStores
+     */
+    public function it_should_create_a_projection_manager(
+        string $expectedProjectionManagerType,
+        EventStore $eventStore
+    ) {
+        $connection = $this->createAPdoObject();
+        $projectionManager = $this->sut->createProjectionManager($eventStore, $connection);
+
+        $this->assertInstanceOf($expectedProjectionManagerType, $projectionManager);
+    }
+
+    public function provideEventStores(): array
+    {
+        $postgresEventStore = $this->createAnEventStore(PostgresEventStore::class);
+        $singleLevelEventStoreDecorator = $this->createAnEventStoreDecorator($postgresEventStore);
+        $multiLevelEventStoreDecorator = $this->createAnEventStoreDecorator($singleLevelEventStoreDecorator);
+
+        return [
+            'InMemoryEventStore' => [
+                InMemoryProjectionManager::class,
+                $this->createAnEventStore(InMemoryEventStore::class),
+            ],
+            'PostgresEventStore' => [
+                PostgresProjectionManager::class,
+                $postgresEventStore,
+            ],
+            'MySqlEventStore' => [
+                MySqlProjectionManager::class,
+                $this->createAnEventStore(MySqlEventStore::class),
+            ],
+            'MariaDbEventStore' => [
+                MariaDbProjectionManager::class,
+                $this->createAnEventStore(MariaDbEventStore::class),
+            ],
+            'Single level EventStoreDecorator' => [
+                PostgresProjectionManager::class,
+                $singleLevelEventStoreDecorator,
+            ],
+            'Multi level InMemoryEventStore' => [
+                PostgresProjectionManager::class,
+                $multiLevelEventStoreDecorator,
+            ],
+        ];
+    }
+
+    private function createAnEventStore(string $type): EventStore
+    {
+        if (InMemoryEventStore::class === $type) {
+            return new InMemoryEventStore();
+        }
+
+        return new $type(
+            $this->createAMessageFactory(),
+            $this->createAPdoObject(),
+            $this->createAPersistenceStrategy()
+        );
+    }
+
+    private function createAMessageFactory(): MessageFactory
+    {
+        return $this->getMockForAbstractClass(MessageFactory::class);
+    }
+
+    private function createAPdoObject(): PDO
+    {
+        return $this->createMock(PDO::class);
+    }
+
+    private function createAPersistenceStrategy(): PersistenceStrategy
+    {
+        return $this->getMockForAbstractClass(PersistenceStrategy::class);
+    }
+
+    private function createAnEventStoreDecorator(EventStore $decoratedEventStore): EventStoreDecorator
+    {
+        $eventStoreDecorator = $this->getMockForAbstractClass(EventStoreDecorator::class);
+        $eventStoreDecorator->expects($this->any())
+            ->method('getInnerEventStore')
+            ->willReturn($decoratedEventStore);
+
+        return $eventStoreDecorator;
+    }
+}

--- a/test/ProjectionManagerFactoryTest.php
+++ b/test/ProjectionManagerFactoryTest.php
@@ -69,7 +69,7 @@ class ProjectionManagerFactoryTest extends TestCase
         $singleLevelEventStoreDecorator = $this->createAnEventStoreDecorator($postgresEventStore);
         $multiLevelEventStoreDecorator = $this->createAnEventStoreDecorator($singleLevelEventStoreDecorator);
 
-        return [
+        $eventStores = [
             'InMemoryEventStore' => [
                 InMemoryProjectionManager::class,
                 $this->createAnEventStore(InMemoryEventStore::class),
@@ -82,10 +82,6 @@ class ProjectionManagerFactoryTest extends TestCase
                 MySqlProjectionManager::class,
                 $this->createAnEventStore(MySqlEventStore::class),
             ],
-            'MariaDbEventStore' => [
-                MariaDbProjectionManager::class,
-                $this->createAnEventStore(MariaDbEventStore::class),
-            ],
             'Single level EventStoreDecorator' => [
                 PostgresProjectionManager::class,
                 $singleLevelEventStoreDecorator,
@@ -95,6 +91,15 @@ class ProjectionManagerFactoryTest extends TestCase
                 $multiLevelEventStoreDecorator,
             ],
         ];
+
+        if (class_exists(MariaDbEventStore::class)) {
+            $eventStores['MariaDbEventStore'] = [
+                MariaDbProjectionManager::class,
+                $this->createAnEventStore(MariaDbEventStore::class),
+            ];
+        }
+
+        return $eventStores;
     }
 
     private function createAnEventStore(string $type): EventStore

--- a/test/ProjectionManagerFactoryTest.php
+++ b/test/ProjectionManagerFactoryTest.php
@@ -92,7 +92,7 @@ class ProjectionManagerFactoryTest extends TestCase
             ],
         ];
 
-        if (class_exists(MariaDbEventStore::class)) {
+        if (\class_exists(MariaDbEventStore::class)) {
             $eventStores['MariaDbEventStore'] = [
                 MariaDbProjectionManager::class,
                 $this->createAnEventStore(MariaDbEventStore::class),


### PR DESCRIPTION
This PR is an improved version of PR #57 by elythyr.

The unit test in the original PR fail when prooph/pdo-event-store v1.0.0 is used.
That version does not contain the MariaDb related classes.

Fix for #55