### PR TITLE
Add support of Symfony 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ doc/html
 .php_cs.cache
 /test/Command/Fixture/var/*
 !/test/Command/Fixture/var/.gitkeep
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,6 @@ jobs:
         - composer require lendable/symfony-messenger-polyfill
         - travis_retry composer update -n --prefer-dist
 
-    # Test against latest Symfony 4.3
-    - php: 7.3
-      env: SYMFONY_REQUIRE="4.3.*"
-      install:
-        - composer require --dev symfony/messenger --no-update
-        - travis_retry composer update -n --prefer-dist
-
     # Test against latest Symfony 4.4
     - php: 7.3
       env: SYMFONY_REQUIRE="4.4.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ script:
 jobs:
   include:
     - php: 7.1
-      env: LOWEST SYMFONY_DEPRECATIONS_HELP=weak
+      env: LOWEST SYMFONY_DEPRECATIONS_HELP=weak SYMFONY_REQUIRE="3.4.*"
       install:
-        - composer require --dev symfony/messenger --no-update
+        - composer require --dev lendable/symfony-messenger-polyfill --no-update
         - travis_retry composer update -n --prefer-lowest --prefer-stable --prefer-dist
 
     - php: 7.2
@@ -39,22 +39,28 @@ jobs:
         - composer require --dev symfony/messenger --no-update
         - travis_retry composer update -n --prefer-dist
 
-    # Test against latest Symfony 3.4
     - php: 7.3
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+
+
+    # Test against latest Symfony 3.4
+    - php: 7.4
       env: SYMFONY_REQUIRE="3.4.*"
       install:
-        - composer require lendable/symfony-messenger-polyfill
+        - composer require --dev lendable/symfony-messenger-polyfill --no-update
         - travis_retry composer update -n --prefer-dist
 
     # Test against latest Symfony 4.4
-    - php: 7.3
+    - php: 7.4
       env: SYMFONY_REQUIRE="4.4.*"
       install:
         - composer require --dev symfony/messenger --no-update
         - travis_retry composer update -n --prefer-dist
 
     # Test against latest Symfony 5.0
-    - php: 7.3
+    - php: 7.4
       env: SYMFONY_REQUIRE="5.0.*"
       install:
         - composer require --dev symfony/messenger --no-update
@@ -62,7 +68,7 @@ jobs:
 
     - stage: Code Quality
       env: CODING_STANDARDS
-      php: 7.3
+      php: 7.4
       install:
         - composer require --dev symfony/messenger --no-update
         - travis_retry composer update -n --prefer-dist
@@ -71,7 +77,7 @@ jobs:
         - ./vendor/bin/phpstan analyse -c phpstan.neon -l 7 src
 
     - stage: Coverage
-      php: 7.3
+      php: 7.4
       install:
         - composer require --dev symfony/messenger --no-update
         - travis_retry composer update -n --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,21 +24,21 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" EXECUTE_CS_CHECK=true COVERAGE=true
     - php: 7.2
     - php: 7.3
-      env: SYMFONY_REQUIRE="4.4.*"
+      env: SYMFONY_REQUIRE="4.3.*"
     - php: 7.4
-      env: SYMFONY_REQUIRE="4.4.*"
+      env: SYMFONY_REQUIRE="4.3.*"
     - php: 7.4
       env: SYMFONY_REQUIRE="5.0.*"
     - php: 7.4
       env: SYMFONY_REQUIRE="5.1.*@dev"
     - php: nightly
-      env: SYMFONY_REQUIRE="4.4.*"
+      env: SYMFONY_REQUIRE="4.3.*"
   allow_failures:
     # Allow failures on next Symfony minor, should always be tested on newest stable PHP branch
     - php: 7.4
       env: SYMFONY_REQUIRE="5.1.*@dev"
     - php: nightly
-      env: SYMFONY_REQUIRE="4.4.*"
+      env: SYMFONY_REQUIRE="4.3.*"
 
 before_install:
   - phpenv config-rm xdebug.ini || return 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: false
-
 language: php
+
+dist: xenial
 
 branches:
   except:
@@ -11,41 +11,50 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.php-cs-fixer
 
-php:
- - 7.1
- - 7.2
-
 env:
   global:
     - EXECUTE_CS_CHECK=false
-    - TEST_COVERAGE=false
-  matrix:
-    - DEPENDENCIES="--prefer-lowest --prefer-stable"
-    - DEPENDENCIES=""
+    - COVERAGE=false
+    - SYMFONY_REQUIRE="3.4.*"
+    - COMPOSER_FLAGS="--prefer-stable"
 
 matrix:
-  fast_finish: true
   include:
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" EXECUTE_CS_CHECK=true COVERAGE=true
     - php: 7.2
-      env: DEPENDENCIES="" EXECUTE_CS_CHECK=true TEST_COVERAGE=true
-  exclude:
-    - php: 7.2
-      env: DEPENDENCIES=""
+    - php: 7.3
+      env: SYMFONY_REQUIRE="4.4.*"
+    - php: 7.4
+      env: SYMFONY_REQUIRE="4.4.*"
+    - php: 7.4
+      env: SYMFONY_REQUIRE="5.0.*"
+    - php: 7.4
+      env: SYMFONY_REQUIRE="5.1.*@dev"
+    - php: nightly
+      env: SYMFONY_REQUIRE="4.4.*"
+  allow_failures:
+    # Allow failures on next Symfony minor, should always be tested on newest stable PHP branch
+    - php: 7.4
+      env: SYMFONY_REQUIRE="5.1.*@dev"
+    - php: nightly
+      env: SYMFONY_REQUIRE="4.4.*"
 
 before_install:
   - phpenv config-rm xdebug.ini || return 0
-  - composer self-update
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --no-update satooshi/php-coveralls:^1.0 ; fi
+  - travis_retry composer self-update
+  - if [[ $COVERAGE == 'true' ]]; then composer require --no-update satooshi/php-coveralls:^1.0 ; fi
 
 install:
-  - travis_retry composer update --no-interaction --prefer-dist $DEPENDENCIES
-  - composer info -i
+  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --no-interaction --quiet; fi
+  - composer update ${COMPOSER_FLAGS} --no-interaction
 
 before_script:
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then mkdir -p "$HOME/.php-cs-fixer" ; fi
+  - composer global require --no-scripts --no-plugins symfony/flex
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
+  - if [[ $COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; fi
   - ./vendor/bin/phpstan analyse -c phpstan.neon -l 7 src
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+sudo: false
 dist: xenial
 
 branches:
@@ -13,53 +13,82 @@ cache:
 
 env:
   global:
-    - EXECUTE_CS_CHECK=false
-    - COVERAGE=false
-    - SYMFONY_REQUIRE="3.4.*"
-    - COMPOSER_FLAGS="--prefer-stable"
-
-matrix:
-  include:
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" EXECUTE_CS_CHECK=true COVERAGE=true
-    - php: 7.2
-    - php: 7.3
-      env: SYMFONY_REQUIRE="4.3.*"
-    - php: 7.4
-      env: SYMFONY_REQUIRE="4.3.*"
-    - php: 7.4
-      env: SYMFONY_REQUIRE="5.0.*"
-    - php: 7.4
-      env: SYMFONY_REQUIRE="5.1.*@dev"
-    - php: nightly
-      env: SYMFONY_REQUIRE="4.3.*"
-  allow_failures:
-    # Allow failures on next Symfony minor, should always be tested on newest stable PHP branch
-    - php: 7.4
-      env: SYMFONY_REQUIRE="5.1.*@dev"
-    - php: nightly
-      env: SYMFONY_REQUIRE="4.3.*"
+    - COMPOSER_MEMORY_LIMIT=-1
 
 before_install:
-  - phpenv config-rm xdebug.ini || return 0
-  - travis_retry composer self-update
-  - if [[ $COVERAGE == 'true' ]]; then composer require --no-update satooshi/php-coveralls:^1.0 ; fi
+  - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+  - composer self-update
+  - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
 
 install:
-  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --no-interaction --quiet; fi
-  - composer update ${COMPOSER_FLAGS} --no-interaction
-
-before_script:
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then mkdir -p "$HOME/.php-cs-fixer" ; fi
-  - composer global require --no-scripts --no-plugins symfony/flex
+  - travis_retry composer update -n --prefer-dist --prefer-stable
 
 script:
-  - if [[ $COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; fi
-  - ./vendor/bin/phpstan analyse -c phpstan.neon -l 7 src
+  - ./vendor/bin/phpunit -v
 
-after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi
+jobs:
+  include:
+    - php: 7.1
+      env: LOWEST SYMFONY_DEPRECATIONS_HELP=weak
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-lowest --prefer-stable --prefer-dist
+
+    - php: 7.2
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+
+    # Test against latest Symfony 3.4
+    - php: 7.3
+      env: SYMFONY_REQUIRE="3.4.*"
+      install:
+        - composer require lendable/symfony-messenger-polyfill
+        - travis_retry composer update -n --prefer-dist
+
+    # Test against latest Symfony 4.3
+    - php: 7.3
+      env: SYMFONY_REQUIRE="4.3.*"
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+
+    # Test against latest Symfony 4.4
+    - php: 7.3
+      env: SYMFONY_REQUIRE="4.4.*"
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+
+    # Test against latest Symfony 5.0
+    - php: 7.3
+      env: SYMFONY_REQUIRE="5.0.*"
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+
+    - stage: Code Quality
+      env: CODING_STANDARDS
+      php: 7.3
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+      script:
+        - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
+        - ./vendor/bin/phpstan analyse -c phpstan.neon -l 7 src
+
+    - stage: Coverage
+      php: 7.3
+      install:
+        - composer require --dev symfony/messenger --no-update
+        - travis_retry composer update -n --prefer-dist
+      before_script:
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
+        - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
+        - composer require --no-update satooshi/php-coveralls:^1.0
+      script:
+        - ./vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
+        - ./vendor/bin/coveralls -v
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,10 @@ jobs:
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
-        - composer require --no-update satooshi/php-coveralls:^1.0
+        - composer require --dev php-coveralls/php-coveralls
       script:
         - ./vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
-        - ./vendor/bin/coveralls -v
+        - ./vendor/bin/php-coveralls -v
 
 notifications:
   webhooks:

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
     "prooph/php-cs-fixer-config": "^0.2.1",
     "matthiasnoback/symfony-dependency-injection-test": "^4.1",
     "phpstan/phpstan": "^0.12",
-    "symfony/messenger": "^4.3 || ^5.0"
+    "symfony/messenger": "^4.3 || ^5.0",
+    "phpstan/phpstan-symfony": "^0.12.1"
   },
   "suggest": {
     "prooph/event-store-bus-bridge": "To Marry CQRS (ProophSerivceBus) with Event Sourcing"

--- a/composer.json
+++ b/composer.json
@@ -64,16 +64,14 @@
     "prooph/event-sourcing": "^5.0",
     "prooph/snapshot-store": "^1.0",
     "prooph/pdo-event-store": "^1.0",
-    "phpunit/phpunit": "^8",
+    "phpunit/phpunit": "^7 || ^8",
     "symfony/yaml" : "^3.4 || ^4.3 || ^5.0",
     "bookdown/bookdown": "1.x-dev as 1.0.0",
     "prooph/bookdown-template": "^0.2.3",
     "friendsofphp/php-cs-fixer": "^2.8.1",
     "prooph/php-cs-fixer-config": "^0.2.1",
-    "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-    "phpstan/phpstan": "^0.12",
-    "symfony/messenger": "^4.3 || ^5.0",
-    "phpstan/phpstan-symfony": "^0.12.1"
+    "matthiasnoback/symfony-dependency-injection-test": "^3.1 || ^4.1",
+    "phpstan/phpstan": "^0.12"
   },
   "suggest": {
     "prooph/event-store-bus-bridge": "To Marry CQRS (ProophSerivceBus) with Event Sourcing"

--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,10 @@
     "php": "^7.1",
     "ext-pdo": "*",
     "ext-json": "*",
-    "symfony/config": "^3.4 || ^4.3 || ^5.0",
-    "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0",
-    "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0",
-    "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
+    "symfony/config": "^3.4 || ^4.4 || ^5.0",
+    "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
+    "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0",
+    "symfony/framework-bundle": "^3.4 || ^4.4 || ^5.0",
     "prooph/event-store": "^7.0"
   },
   "require-dev": {
@@ -65,7 +65,7 @@
     "prooph/snapshot-store": "^1.0",
     "prooph/pdo-event-store": "^1.0",
     "phpunit/phpunit": "^7 || ^8",
-    "symfony/yaml" : "^3.4 || ^4.3 || ^5.0",
+    "symfony/yaml" : "^3.4 || ^4.4 || ^5.0",
     "bookdown/bookdown": "1.x-dev as 1.0.0",
     "prooph/bookdown-template": "^0.2.3",
     "friendsofphp/php-cs-fixer": "^2.8.1",

--- a/composer.json
+++ b/composer.json
@@ -52,25 +52,27 @@
   },
   "require": {
     "php": "^7.1",
-    "symfony/config": "^3.3 || ^4.0",
-    "symfony/dependency-injection": "^3.3 || ^4.0",
-    "symfony/http-kernel": "^3.3 || ^4.0",
-    "symfony/framework-bundle": "^3.3 || ^4.0",
+    "ext-pdo": "*",
+    "ext-json": "*",
+    "symfony/config": "^3.4 || ^4.3 || ^5.0",
+    "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0",
+    "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0",
+    "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
     "prooph/event-store": "^7.0"
   },
   "require-dev": {
     "prooph/event-sourcing": "^5.0",
     "prooph/snapshot-store": "^1.0",
     "prooph/pdo-event-store": "^1.0",
-    "phpunit/phpunit": "^6",
-    "symfony/yaml" : "^3.3 || ^4.0",
+    "phpunit/phpunit": "^8",
+    "symfony/yaml" : "^3.4 || ^4.3 || ^5.0",
     "bookdown/bookdown": "1.x-dev as 1.0.0",
     "prooph/bookdown-template": "^0.2.3",
     "friendsofphp/php-cs-fixer": "^2.8.1",
     "prooph/php-cs-fixer-config": "^0.2.1",
-    "matthiasnoback/symfony-dependency-injection-test": "^2.3",
-    "phpstan/phpstan": "^0.9.2",
-    "symfony/messenger": "^4.3"
+    "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+    "phpstan/phpstan": "^0.12",
+    "symfony/messenger": "^4.3 || ^5.0"
   },
   "suggest": {
     "prooph/event-store-bus-bridge": "To Marry CQRS (ProophSerivceBus) with Event Sourcing"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 parameters:
     reportUnmatchedIgnoredErrors: false
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
         # Only available in ArrayNodeDefinition which is given
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)\.#'
@@ -9,6 +11,7 @@ parameters:
         # TreeBuilder in Symfony 4.2 and up has a constructor and a getRootNode() method
         - '#Class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder does not have a constructor and must be instantiated without any parameters\.#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::getRootNode\(\)#'
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root\(\)#'
         # More Symfony 4.2 compatibility errors
         - '#Parameter \#2 \$deleteEmittedEvents of method Prooph\\EventStore\\Projection\\ProjectionManager::deleteProjection\(\) expects bool, array<string>\|bool\|string\|null given\.#'
         - '#Property Prooph\\Bundle\\EventStore\\Command\\AbstractProjectionCommand::\$projectionName \(string\) does not accept array<string>\|string\|null\.#'
@@ -19,3 +22,4 @@ parameters:
         - '#Class Prooph\\EventStore\\Pdo\\MariaDbEventStore not found\.#'
         - '#Method Prooph\\Bundle\\EventStore\\ProjectionManagerFactory::createProjectionManager\(\) should return Prooph\\EventStore\\Projection\\ProjectionManager but returns Prooph\\EventStore\\Pdo\\Projection\\MariaDbProjectionManager\.#'
         - '#Instantiated class Prooph\\EventStore\\Pdo\\Projection\\MariaDbProjectionManager not found\.#'
+        - '#Parameter \#1 $argument of class ReflectionClass constructor expects class-string<T of object>\|T of object, string\|null given.#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,7 @@
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         syntaxCheck="true"
+         convertWarningsToExceptions="false"
          backupGlobals="true"
          backupStaticAttributes="false">
 

--- a/src/Command/AbstractProjectionCommand.php
+++ b/src/Command/AbstractProjectionCommand.php
@@ -89,18 +89,18 @@ abstract class AbstractProjectionCommand extends Command
         $this->projectionName = $input->getArgument(static::ARGUMENT_PROJECTION_NAME);
 
         if (! $this->projectionManagerForProjectionsLocator->has($this->projectionName)) {
-            throw new RuntimeException(\vsprintf('ProjectionManager for "%s" not found', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
+            throw new RuntimeException(\vsprintf('ProjectionManager for "%s" not found', \is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
         }
         $this->projectionManager = $this->projectionManagerForProjectionsLocator->get($this->projectionName);
 
         if (! $this->projectionsLocator->has($this->projectionName)) {
-            throw new RuntimeException(\vsprintf('Projection "%s" not found', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
+            throw new RuntimeException(\vsprintf('Projection "%s" not found', \is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
         }
         $this->projection = $this->projectionsLocator->get($this->projectionName);
 
         if ($this->projection instanceof ReadModelProjection) {
             if (! $this->projectionReadModelLocator->has($this->projectionName)) {
-                throw new RuntimeException(\vsprintf('ReadModel for "%s" not found', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
+                throw new RuntimeException(\vsprintf('ReadModel for "%s" not found', \is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
             }
             $this->readModel = $this->projectionReadModelLocator->get($this->projectionName);
 
@@ -114,7 +114,7 @@ abstract class AbstractProjectionCommand extends Command
         if (null === $this->projector) {
             throw new RuntimeException('Projection was not created');
         }
-        $output->writeln(\vsprintf('<header>Initialized projection "%s"</header>', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
+        $output->writeln(\vsprintf('<header>Initialized projection "%s"</header>', \is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
         try {
             $state = $this->projectionManager->fetchProjectionStatus($this->projectionName)->getValue();
         } catch (\Prooph\EventStore\Exception\RuntimeException $e) {

--- a/src/Command/AbstractProjectionCommand.php
+++ b/src/Command/AbstractProjectionCommand.php
@@ -75,12 +75,12 @@ abstract class AbstractProjectionCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument(static::ARGUMENT_PROJECTION_NAME, InputArgument::REQUIRED, 'The name of the Projection');
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $input->validate();
 
@@ -89,18 +89,18 @@ abstract class AbstractProjectionCommand extends Command
         $this->projectionName = $input->getArgument(static::ARGUMENT_PROJECTION_NAME);
 
         if (! $this->projectionManagerForProjectionsLocator->has($this->projectionName)) {
-            throw new RuntimeException(\sprintf('ProjectionManager for "%s" not found', $this->projectionName));
+            throw new RuntimeException(\vsprintf('ProjectionManager for "%s" not found', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
         }
         $this->projectionManager = $this->projectionManagerForProjectionsLocator->get($this->projectionName);
 
         if (! $this->projectionsLocator->has($this->projectionName)) {
-            throw new RuntimeException(\sprintf('Projection "%s" not found', $this->projectionName));
+            throw new RuntimeException(\vsprintf('Projection "%s" not found', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
         }
         $this->projection = $this->projectionsLocator->get($this->projectionName);
 
         if ($this->projection instanceof ReadModelProjection) {
             if (! $this->projectionReadModelLocator->has($this->projectionName)) {
-                throw new RuntimeException(\sprintf('ReadModel for "%s" not found', $this->projectionName));
+                throw new RuntimeException(\vsprintf('ReadModel for "%s" not found', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
             }
             $this->readModel = $this->projectionReadModelLocator->get($this->projectionName);
 
@@ -114,7 +114,7 @@ abstract class AbstractProjectionCommand extends Command
         if (null === $this->projector) {
             throw new RuntimeException('Projection was not created');
         }
-        $output->writeln(\sprintf('<header>Initialized projection "%s"</header>', $this->projectionName));
+        $output->writeln(\vsprintf('<header>Initialized projection "%s"</header>', is_array($this->projectionName) ? $this->projectionName : [$this->projectionName]));
         try {
             $state = $this->projectionManager->fetchProjectionStatus($this->projectionName)->getValue();
         } catch (\Prooph\EventStore\Exception\RuntimeException $e) {

--- a/src/Command/FormatsOutput.php
+++ b/src/Command/FormatsOutput.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait FormatsOutput
 {
-    protected function formatOutput(OutputInterface $output)
+    protected function formatOutput(OutputInterface $output): void
     {
         $outputFormatter = $output->getFormatter();
         $outputFormatter->setStyle('header', new OutputFormatterStyle('green', null));

--- a/src/Command/ProjectionDeleteCommand.php
+++ b/src/Command/ProjectionDeleteCommand.php
@@ -12,7 +12,7 @@ class ProjectionDeleteCommand extends AbstractProjectionCommand
 {
     protected const OPTION_WITH_EVENTS = 'with-emitted-events';
 
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this
@@ -21,7 +21,7 @@ class ProjectionDeleteCommand extends AbstractProjectionCommand
             ->addOption(static::OPTION_WITH_EVENTS, 'w', InputOption::VALUE_NONE, 'Delete with emitted events');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $withEvents = $input->getOption(self::OPTION_WITH_EVENTS);
         if ($withEvents) {
@@ -30,5 +30,7 @@ class ProjectionDeleteCommand extends AbstractProjectionCommand
             $output->writeln(\sprintf('<action>Deleting projection </action><highlight>%s</highlight>', $this->projectionName));
         }
         $this->projectionManager->deleteProjection($this->projectionName, $withEvents);
+
+        return 0;
     }
 }

--- a/src/Command/ProjectionNamesCommand.php
+++ b/src/Command/ProjectionNamesCommand.php
@@ -40,7 +40,7 @@ class ProjectionNamesCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('event-store:projection:names')
@@ -64,6 +64,7 @@ class ProjectionNamesCommand extends Command
             });
         }
 
+        /** @var string|null $filter */
         $filter = $input->getArgument(self::ARGUMENT_FILTER);
         $regex = $input->getOption(static::OPTION_REGEX);
 
@@ -80,8 +81,10 @@ class ProjectionNamesCommand extends Command
         $output->writeln('</action>');
 
         $names = [];
-        $offset = (int) $input->getOption(self::OPTION_OFFSET);
-        $limit = (int) $input->getOption(self::OPTION_LIMIT);
+        /** @var int $offset */
+        $offset = $input->getOption(self::OPTION_OFFSET);
+        /** @var int $limit */
+        $limit = $input->getOption(self::OPTION_LIMIT);
         $maxNeeded = $offset + $limit;
 
         foreach ($managerNames as $managerName) {

--- a/src/Command/ProjectionNamesCommand.php
+++ b/src/Command/ProjectionNamesCommand.php
@@ -110,5 +110,7 @@ class ProjectionNamesCommand extends Command
             ->setRows($names);
 
         $table->render();
+
+        return 0;
     }
 }

--- a/src/Command/ProjectionResetCommand.php
+++ b/src/Command/ProjectionResetCommand.php
@@ -21,5 +21,7 @@ class ProjectionResetCommand extends AbstractProjectionCommand
     {
         $output->writeln(\sprintf('<action>Resetting projection <highlight>%s</highlight></action>', $this->projectionName));
         $this->projectionManager->resetProjection($this->projectionName);
+
+        return 0;
     }
 }

--- a/src/Command/ProjectionResetCommand.php
+++ b/src/Command/ProjectionResetCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProjectionResetCommand extends AbstractProjectionCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this

--- a/src/Command/ProjectionRunCommand.php
+++ b/src/Command/ProjectionRunCommand.php
@@ -34,5 +34,7 @@ class ProjectionRunCommand extends AbstractProjectionCommand
         $projector = $this->projection->project($this->projector);
         $projector->run($keepRunning);
         $output->writeln(\sprintf('<action>Projection <highlight>%s</highlight> completed.</action>', $this->projectionName));
+
+        return 0;
     }
 }

--- a/src/Command/ProjectionStateCommand.php
+++ b/src/Command/ProjectionStateCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProjectionStateCommand extends AbstractProjectionCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this
@@ -20,7 +20,10 @@ class ProjectionStateCommand extends AbstractProjectionCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('<action>Current state:</action>');
-        $output->writeln(\json_encode($this->projectionManager->fetchProjectionState($this->projectionName)));
+
+        /** @var string $state */
+        $state = \json_encode($this->projectionManager->fetchProjectionState($this->projectionName));
+        $output->writeln($state);
 
         return 0;
     }

--- a/src/Command/ProjectionStateCommand.php
+++ b/src/Command/ProjectionStateCommand.php
@@ -21,5 +21,7 @@ class ProjectionStateCommand extends AbstractProjectionCommand
     {
         $output->writeln('<action>Current state:</action>');
         $output->writeln(\json_encode($this->projectionManager->fetchProjectionState($this->projectionName)));
+
+        return 0;
     }
 }

--- a/src/Command/ProjectionStopCommand.php
+++ b/src/Command/ProjectionStopCommand.php
@@ -21,5 +21,7 @@ class ProjectionStopCommand extends AbstractProjectionCommand
     {
         $output->writeln(\sprintf('<action>Stopping projection <highlight>%s</highlight></action>', $this->projectionName));
         $this->projectionManager->stopProjection($this->projectionName);
+
+        return 0;
     }
 }

--- a/src/Command/ProjectionStopCommand.php
+++ b/src/Command/ProjectionStopCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProjectionStopCommand extends AbstractProjectionCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this

--- a/src/Command/ProjectionStreamPositionsCommand.php
+++ b/src/Command/ProjectionStreamPositionsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProjectionStreamPositionsCommand extends AbstractProjectionCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this

--- a/src/Command/ProjectionStreamPositionsCommand.php
+++ b/src/Command/ProjectionStreamPositionsCommand.php
@@ -26,5 +26,7 @@ class ProjectionStreamPositionsCommand extends AbstractProjectionCommand
             $table->addRow([$stream, $position]);
         }
         $table->render();
+
+        return 0;
     }
 }

--- a/src/DependencyInjection/Compiler/MetadataEnricherPass.php
+++ b/src/DependencyInjection/Compiler/MetadataEnricherPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MetadataEnricherPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (! $container->hasParameter('prooph_event_store.stores')) {
             return;
@@ -30,6 +30,8 @@ class MetadataEnricherPass implements CompilerPassInterface
 
         foreach ($stores as $name => $store) {
             $storeEnricherPlugins = $container->findTaggedServiceIds(\sprintf('prooph_event_store.%s.metadata_enricher', $name));
+
+            /** @var array<string, string> $plugins */
             $plugins = \array_merge($globalPlugins, $storeEnricherPlugins);
             $enrichers = [];
 

--- a/src/DependencyInjection/Compiler/PluginLocatorPass.php
+++ b/src/DependencyInjection/Compiler/PluginLocatorPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class PluginLocatorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (! $container->hasParameter('prooph_event_store.stores')) {
             return;
@@ -28,6 +28,7 @@ final class PluginLocatorPass implements CompilerPassInterface
             $storePlugins[] = $container->findTaggedServiceIds(\sprintf('prooph_event_store.%s.plugin', $name));
         }
 
+        /** @var array<string, string> $plugins */
         $plugins = \array_merge($globalPlugins, ...$storePlugins);
 
         $locatorPlugins = [];

--- a/src/DependencyInjection/Compiler/PluginsPass.php
+++ b/src/DependencyInjection/Compiler/PluginsPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PluginsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (! $container->hasParameter('prooph_event_store.stores')) {
             return;

--- a/src/DependencyInjection/Compiler/RegisterProjectionsPass.php
+++ b/src/DependencyInjection/Compiler/RegisterProjectionsPass.php
@@ -39,7 +39,9 @@ final class RegisterProjectionsPass implements CompilerPassInterface
 
         foreach ($projectionIds as $id) {
             $projectorDefinition = $container->getDefinition($id);
-            $projectionClass = new ReflectionClass($projectorDefinition->getClass());
+            /** @var object $projectorDefinitionClass */
+            $projectorDefinitionClass = $projectorDefinition->getClass();
+            $projectionClass = new ReflectionClass($projectorDefinitionClass);
 
             self::assertProjectionHasAValidClass($id, $projectionClass);
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ final class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('prooph_event_store');
         // Keep compatibility with symfony/config < 4.2
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
+        if (! \method_exists($treeBuilder, 'getRootNode')) {
             $root = $treeBuilder->root('prooph_event_store');
         } else {
             $root = $treeBuilder->getRootNode();
@@ -44,7 +44,7 @@ final class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('projections');
         // Keep compatibility with symfony/config < 4.2
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
+        if (! \method_exists($treeBuilder, 'getRootNode')) {
             $projectionsNode = $treeBuilder->root('projections');
         } else {
             $projectionsNode = $treeBuilder->getRootNode();
@@ -115,7 +115,7 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('repositories');
 
         // Keep compatibility with symfony/config < 4.2
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
+        if (! \method_exists($treeBuilder, 'getRootNode')) {
             $repositoriesNode = $treeBuilder->root('repositories');
         } else {
             $repositoriesNode = $treeBuilder->getRootNode();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,12 +27,15 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('prooph_event_store');
-        /** @var ArrayNodeDefinition $rootNode */
-        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode') ?
-            $treeBuilder->getRootNode() : $treeBuilder->root('prooph_event_store');
+        // Keep compatibility with symfony/config < 4.2
+        if (!\method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->root('prooph_event_store');
+        } else {
+            $root = $treeBuilder->getRootNode();
+        }
 
-        $this->addEventStoreSection($rootNode);
-        $this->addProjectionManagerSection($rootNode);
+        $this->addEventStoreSection($root);
+        $this->addProjectionManagerSection($root);
 
         return $treeBuilder;
     }
@@ -40,9 +43,12 @@ final class Configuration implements ConfigurationInterface
     public function addProjectionManagerSection(ArrayNodeDefinition $node): void
     {
         $treeBuilder = new TreeBuilder('projections');
-        /** @var ArrayNodeDefinition $projectionsNode */
-        $projectionsNode = \method_exists(TreeBuilder::class, 'getRootNode') ?
-            $treeBuilder->getRootNode() : $treeBuilder->root('projections');
+        // Keep compatibility with symfony/config < 4.2
+        if (!\method_exists($treeBuilder, 'getRootNode')) {
+            $projectionsNode = $treeBuilder->root('projections');
+        } else {
+            $projectionsNode = $treeBuilder->getRootNode();
+        }
 
         $beginsWithAt = function ($v) {
             return \strpos($v, '@') === 0;
@@ -107,9 +113,13 @@ final class Configuration implements ConfigurationInterface
     private function addEventStoreSection(ArrayNodeDefinition $node): void
     {
         $treeBuilder = new TreeBuilder('repositories');
-        /** @var ArrayNodeDefinition $repositoriesNode */
-        $repositoriesNode = \method_exists(TreeBuilder::class, 'getRootNode') ?
-            $treeBuilder->getRootNode() : $treeBuilder->root('repositories');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (!\method_exists($treeBuilder, 'getRootNode')) {
+            $repositoriesNode = $treeBuilder->root('repositories');
+        } else {
+            $repositoriesNode = $treeBuilder->getRootNode();
+        }
 
         $beginsWithAt = function ($v) {
             return \strpos($v, '@') === 0;

--- a/src/DependencyInjection/ProophEventStoreExtension.php
+++ b/src/DependencyInjection/ProophEventStoreExtension.php
@@ -134,7 +134,7 @@ final class ProophEventStoreExtension extends Extension
      * @param array            $config
      * @param ContainerBuilder $container
      */
-    private function loadEventStores(string $class, array $config, ContainerBuilder $container)
+    private function loadEventStores(string $class, array $config, ContainerBuilder $container): void
     {
         $eventStores = [];
 
@@ -163,7 +163,7 @@ final class ProophEventStoreExtension extends Extension
      * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @throws \Prooph\Bundle\EventStore\Exception\RuntimeException
      */
-    private function loadEventStore(string $name, array $options, ContainerBuilder $container)
+    private function loadEventStore(string $name, array $options, ContainerBuilder $container): void
     {
         $eventStoreId = 'prooph_event_store.'.$name;
         $eventStoreDefinition = $container

--- a/src/ProophEventStoreBundle.php
+++ b/src/ProophEventStoreBundle.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class ProophEventStoreBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/RepositoryFactory.php
+++ b/src/RepositoryFactory.php
@@ -19,6 +19,9 @@ use Prooph\SnapshotStore\SnapshotStore;
 
 class RepositoryFactory
 {
+    /**
+     * @return mixed
+     */
     public function create(
         string $repositoryClass,
         EventStore $eventStore,

--- a/test/Command/Fixture/TestKernel.php
+++ b/test/Command/Fixture/TestKernel.php
@@ -21,12 +21,12 @@ class TestKernel extends Kernel
 
     public function getLogDir(): string
     {
-        return $this->getRootDir() . '/var/logs';
+        return $this->getProjectDir() . '/test/Command/Fixture/var/logs';
     }
 
     public function getCacheDir()
     {
-        return $this->getRootDir() . '/var/cache';
+        return $this->getProjectDir() . '/test/Command/Fixture/var/cache';
     }
 
     public function build(ContainerBuilder $container)

--- a/test/DependencyInjection/Compiler/DeprecateFqcnProjectionsPassTest.php
+++ b/test/DependencyInjection/Compiler/DeprecateFqcnProjectionsPassTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class DeprecateFqcnProjectionsPassTest extends CompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new DeprecateFqcnProjectionsPass());
     }

--- a/test/DependencyInjection/Compiler/MetadataEnricherPassTest.php
+++ b/test/DependencyInjection/Compiler/MetadataEnricherPassTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MetadataEnricherPassTest extends CompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new MetadataEnricherPass());
     }

--- a/test/DependencyInjection/Compiler/PluginsPassTest.php
+++ b/test/DependencyInjection/Compiler/PluginsPassTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class PluginsPassTest extends CompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new PluginsPass());
     }

--- a/test/DependencyInjection/ConfigurationTest.php
+++ b/test/DependencyInjection/ConfigurationTest.php
@@ -15,15 +15,17 @@ use ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleAggr
 use ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository;
 use ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoProjection;
 use ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
-    protected function getContainerExtension()
+    protected function getContainerExtension(): ExtensionInterface
     {
         return new ProophEventStoreExtension();
     }
 
-    protected function getConfiguration()
+    protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();
     }

--- a/test/DependencyInjection/Fixture/config/xml/event_store.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_store.xml
@@ -36,6 +36,7 @@
 
     <srv:services>
         <srv:service id="Prooph\EventStore\InMemoryEventStore" class="Prooph\EventStore\InMemoryEventStore" />
+        <srv:service id="ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel" />
         <srv:service id="test.prooph_event_store.main_store" alias="prooph_event_store.main_store" public="true" />
         <srv:service id="test.todo_list" alias="todo_list" public="true" />
         <srv:service id="test.ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository" alias="ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Model\BlackHoleRepository" public="true" />

--- a/test/DependencyInjection/Fixture/config/yml/event_store.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_store.yml
@@ -25,6 +25,8 @@ services:
   Prooph\EventStore\InMemoryEventStore:
     class: Prooph\EventStore\InMemoryEventStore
 
+  ProophTest\Bundle\EventStore\DependencyInjection\Fixture\Projection\TodoReadModel: ~
+
   test.prooph_event_store.main_store:
     alias: prooph_event_store.main_store
     public: true

--- a/test/Messenger/EventStoreTransactionMiddlewareTest.php
+++ b/test/Messenger/EventStoreTransactionMiddlewareTest.php
@@ -54,6 +54,10 @@ class EventStoreTransactionMiddlewareTest extends MiddlewareTestCase
 
     public function testItResetsHandledStampsOnHandlerFailedException(): void
     {
+        if (! class_exists(HandlerFailedException::class)) {
+            $this->markTestSkipped('Symfony Messenger 4.2 does not support HandlerFailedException');
+        }
+
         $this->eventStore->expects($this->once())
             ->method('beginTransaction');
         $this->eventStore->expects($this->once())

--- a/test/Messenger/EventStoreTransactionMiddlewareTest.php
+++ b/test/Messenger/EventStoreTransactionMiddlewareTest.php
@@ -8,6 +8,7 @@ use LogicException;
 use Prooph\Bundle\EventStore\Messenger\EventStoreTransactionMiddleware;
 use Prooph\EventStore\TransactionalEventStore;
 use stdClass;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
@@ -58,9 +59,7 @@ class EventStoreTransactionMiddlewareTest extends MiddlewareTestCase
         $this->eventStore->expects($this->once())
             ->method('rollback');
 
-        $envelop = new Envelope(new stdClass(), [
-            new HandledStamp('dummy', 'dummy'),
-        ]);
+        $envelop = (new Envelope(new stdClass()))->with(new HandledStamp('dummy', 'dummy'));
 
         $exception = null;
         try {

--- a/test/Messenger/EventStoreTransactionMiddlewareTest.php
+++ b/test/Messenger/EventStoreTransactionMiddlewareTest.php
@@ -8,7 +8,6 @@ use LogicException;
 use Prooph\Bundle\EventStore\Messenger\EventStoreTransactionMiddleware;
 use Prooph\EventStore\TransactionalEventStore;
 use stdClass;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
@@ -54,7 +53,7 @@ class EventStoreTransactionMiddlewareTest extends MiddlewareTestCase
 
     public function testItResetsHandledStampsOnHandlerFailedException(): void
     {
-        if (! class_exists(HandlerFailedException::class)) {
+        if (! \class_exists(HandlerFailedException::class)) {
             $this->markTestSkipped('Symfony Messenger 4.2 does not support HandlerFailedException');
         }
 

--- a/test/ProjectionManagerFactoryTest.php
+++ b/test/ProjectionManagerFactoryTest.php
@@ -28,7 +28,7 @@ class ProjectionManagerFactoryTest extends TestCase
      */
     private $sut;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->sut = new ProjectionManagerFactory();
     }


### PR DESCRIPTION
I tried to support maximum version of Symfony LTS versions.

Because of https://github.com/SymfonyTest/SymfonyDependencyInjectionTest 's requirements, I've dropped 4.3 version (4.4 is now a LTS).

I've reworked the travis CI configuration to support Symfony Messenger in both 3.4 and >=4. 
+ Tests now pass with all LTS versions of Symfony (3.4, 4.4, 5.0)