### PR TITLE
Bugfix for missing return type `TreeBuilder` from `ConfigurationInterface` in Symfony 7

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ final class Configuration implements ConfigurationInterface
      *
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('prooph_event_store');
         // Keep compatibility with symfony/config < 4.2


### PR DESCRIPTION
Fixes this incompatibility with Symfony 7 (or `symfony/config:^7.0` to be precise):
```
PHP Fatal error:  Declaration of Prooph\Bundle\EventStore\DependencyInjection\Configuration::getConfigTreeBuilder() must be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder(): Symfony\Component\Config\Definition\Builder\TreeBuilder in /.../vendor/prooph/event-store-symfony-bundle/src/DependencyInjection/Configuration.php on line 29
```

P.S. For whatever reason running `composer install` in this bundle's repository, even with `--no-dev` still refuses to install `symfony/config` v7.0+ - so the issue is not immediately obvious, but it popped up in an actual project.
Heres symfony interface now: https://github.com/symfony/symfony/blob/7.0/src/Symfony/Component/Config/Definition/ConfigurationInterface.php 