### PR TITLE
Allow newer symfony-dic-test for symfony7 compatibility in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "prooph/bookdown-template": "^0.3",
     "friendsofphp/php-cs-fixer": "^3.5",
     "prooph/php-cs-fixer-config": "^0.5.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^3.1 || ^4.1",
+    "matthiasnoback/symfony-dependency-injection-test": "^3.1 || ^4.1 || ^5.1",
     "phpstan/phpstan": "^1.5"
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
`matthiasnoback/symfony-dependency-injection-test `v4.x` requires `symfony/dependency-injection` of up to 6.4.x only, thus v7.0 is never installed/tested