### PR TITLE
Actually use symfony matrix in tests

### DIFF
--- a/.github/workflows/static-analyse.yml
+++ b/.github/workflows/static-analyse.yml
@@ -19,7 +19,7 @@ jobs:
             CODING_STANDARDS: 1
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v4"
 
             -   name: "Setup PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -34,7 +34,7 @@ jobs:
                     echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             -   name: "Cache Composer dependencies"
-                uses: "actions/cache@v2"
+                uses: "actions/cache@v4"
                 with:
                     path: |
                         ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,11 @@ jobs:
                     restore-keys: |
                         php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
 
-            -   name: "Require php-coveralls/php-coveralls"
-                run: "composer global require php-coveralls/php-coveralls"
+            -   name: "Require php-coveralls/php-coveralls and symfony/flex"
+                run: "composer global require php-coveralls/php-coveralls symfony/flex --no-scripts --no-plugins"
 
             -   name: "Install dependencies"
-                run: "composer update -n --prefer-dist"
+                run: "SYMFONY_REQUIRE='${{ matrix.symfony-version }}' composer update -n --prefer-dist"
 
             -   name: "Test"
                 run: "composer test-coverage"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,9 @@ jobs:
             -   name: "Require php-coveralls/php-coveralls and symfony/flex"
                 run: "composer global require php-coveralls/php-coveralls symfony/flex --no-scripts --no-plugins"
 
+            -   name: "Enable symfony/flex plugin"
+                run: "composer global config --no-scripts --no-plugins allow-plugins.symfony/flex true"
+
             -   name: "Install dependencies"
                 run: "SYMFONY_REQUIRE='${{ matrix.symfony-version }}' composer update -n --prefer-dist"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
             COMPOSER_MEMORY_LIMIT: -1
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v4"
 
             -   name: "Setup PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -43,7 +43,7 @@ jobs:
                 run: |
                     echo "::set-output name=dir::$(composer config cache-files-dir)"
             -   name: "Cache Composer dependencies"
-                uses: "actions/cache@v2"
+                uses: "actions/cache@v4"
                 with:
                     path: |
                         ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
                     - "8.3"
                 operating-system:
                     - "ubuntu-latest"
+                exclude:
+                    - symfony-version: "7.0.*"
+                      php-version: "8.1"
 
         runs-on: ${{ matrix.operating-system }}
         env:

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "prooph/bookdown-template": "^0.3",
     "friendsofphp/php-cs-fixer": "^3.5",
     "prooph/php-cs-fixer-config": "^0.5.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^3.1 || ^4.1",
+    "matthiasnoback/symfony-dependency-injection-test": "^3.1 || ^4.1 || ^5.1",
     "phpstan/phpstan": "^1.5"
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
By adding `symfony/flex` globally and passing `SYMFONY_REQUIRE` env param it ensures that all symfony packages are coming from the same symfony-version provided by the test matrix.

P.S. This also includes https://github.com/prooph/event-store-symfony-bundle/pull/96 as otherwise unable to build `7.0.*` branch due to incompatibilities.